### PR TITLE
Add optional raw occupancy map thresholding

### DIFF
--- a/camap/analysis/spatial_1d.py
+++ b/camap/analysis/spatial_1d.py
@@ -96,6 +96,7 @@ def compute_occupancy_map_1d(
     pos_column: str = "pos_1d",
     segment_bins: list[int] | None = None,
     edges: np.ndarray | None = None,
+    occupancy_mask: str = "smoothed",
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Compute 1D occupancy histogram (raw).
 
@@ -117,12 +118,15 @@ def compute_occupancy_map_1d(
         downstream smoothing in the rate-map/SI path doesn't compound
         to sigma·sqrt(2).
     min_occupancy:
-        Minimum occupancy in seconds (checked against the smoothed
-        occupancy for the mask).
+        Minimum occupancy in seconds for a bin to count as valid.
     pos_column:
         Column name for position values.
     segment_bins:
         Bin boundary indices for per-segment smoothing.
+    occupancy_mask:
+        ``"raw"`` gates ``min_occupancy`` on raw per-bin occupancy
+        (typical); ``"smoothed"`` gates on the Gaussian-smoothed
+        occupancy (legacy), letting never-visited bins pass.
     edges:
         Explicit bin edges. When provided, these are used as-is (e.g.
         per-arm edges where boundaries land exactly on edges and bin
@@ -142,7 +146,7 @@ def compute_occupancy_map_1d(
     counts, _ = np.histogram(trajectory_df[pos_column], bins=edges)
     occupancy_time = counts.astype(float) * time_per_frame
 
-    if spatial_sigma > 0:
+    if occupancy_mask == "smoothed" and spatial_sigma > 0:
         occ_for_mask = gaussian_filter_normalized_1d(
             occupancy_time, sigma=spatial_sigma, segment_bins=segment_bins
         )
@@ -354,6 +358,7 @@ def compute_stability_score_1d(
     si_weight_mode: str = "amplitude",
     pos_column: str = "pos_1d",
     segment_bins: list[int] | None = None,
+    occupancy_mask: str = "smoothed",
 ) -> tuple[float, float, float, np.ndarray, np.ndarray, np.ndarray]:
     """Compute 1D split-half stability test.
 
@@ -415,10 +420,13 @@ def compute_stability_score_1d(
             return np.zeros_like(occupancy_time), np.zeros_like(valid_mask, dtype=bool)
         counts, _ = np.histogram(traj_half[pos_column], bins=edges)
         occ = counts.astype(float) * time_per_frame
-        occ_smooth = gaussian_filter_normalized_1d(
-            occ, sigma=spatial_sigma, segment_bins=segment_bins
-        )
-        mask = occ_smooth >= min_occupancy
+        if occupancy_mask == "smoothed" and spatial_sigma > 0:
+            occ_for_mask = gaussian_filter_normalized_1d(
+                occ, sigma=spatial_sigma, segment_bins=segment_bins
+            )
+        else:
+            occ_for_mask = occ
+        mask = occ_for_mask >= min_occupancy
         return occ, mask
 
     occ_first, valid_first = compute_half_occupancy(traj_first)
@@ -658,6 +666,7 @@ def compute_unit_analysis_1d(
                 si_weight_mode=scfg.si_weight_mode,
                 pos_column=pos_column,
                 segment_bins=segment_bins,
+                occupancy_mask=scfg.occupancy_mask,
             )
         stability_splits.append(
             {

--- a/camap/analysis/spatial_2d.py
+++ b/camap/analysis/spatial_2d.py
@@ -86,6 +86,7 @@ def compute_occupancy_map(
     behavior_fps: float,
     spatial_sigma: float = 1.0,
     min_occupancy: float = 0.1,
+    occupancy_mask: str = "smoothed",
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Compute raw occupancy map from speed-filtered trajectory.
 
@@ -103,15 +104,19 @@ def compute_occupancy_map(
         is returned unsmoothed so downstream smoothing in
         :func:`compute_rate_map` etc. doesn't compound to sigma·sqrt(2).
     min_occupancy:
-        Minimum occupancy time in seconds (checked against the smoothed
-        occupancy for the mask).
+        Minimum occupancy time in seconds for a bin to count as valid.
+    occupancy_mask:
+        ``"raw"`` gates the ``min_occupancy`` threshold on the raw per-bin
+        occupancy (typical). ``"smoothed"`` gates on the Gaussian-smoothed
+        occupancy (legacy), which lets never-visited bins pass by borrowing
+        dwell time from neighbors.
 
     Returns
     -------
     tuple
         (occupancy_time, valid_mask, x_edges, y_edges) — ``occupancy_time``
-        is raw (seconds per bin); ``valid_mask`` comes from the smoothed
-        copy.
+        is always raw (seconds per bin); ``valid_mask`` gates on raw or
+        smoothed occupancy per ``occupancy_mask``.
     """
     x_edges = np.linspace(trajectory_df["x"].min(), trajectory_df["x"].max(), bins + 1)
     y_edges = np.linspace(trajectory_df["y"].min(), trajectory_df["y"].max(), bins + 1)
@@ -122,7 +127,7 @@ def compute_occupancy_map(
     )
     occupancy_time = occupancy_counts * time_per_frame
 
-    if spatial_sigma > 0:
+    if occupancy_mask == "smoothed" and spatial_sigma > 0:
         occ_for_mask = gaussian_filter_normalized(occupancy_time, sigma=spatial_sigma)
     else:
         occ_for_mask = occupancy_time
@@ -458,6 +463,7 @@ def compute_stability_score(
     random_seed: int | None = None,
     min_shift_seconds: float = 0.0,
     si_weight_mode: str = "amplitude",
+    occupancy_mask: str = "smoothed",
 ) -> tuple[float, float, float, np.ndarray, np.ndarray, np.ndarray]:
     """Compute stability score by comparing rate maps from split data.
 
@@ -575,8 +581,11 @@ def compute_stability_score(
             return occ, mask
         counts, _, _ = np.histogram2d(traj_half["x"], traj_half["y"], bins=[x_edges, y_edges])
         occ = counts * time_per_frame
-        occ_smooth = gaussian_filter_normalized(occ, sigma=spatial_sigma)
-        mask = occ_smooth >= min_occupancy
+        if occupancy_mask == "smoothed" and spatial_sigma > 0:
+            occ_for_mask = gaussian_filter_normalized(occ, sigma=spatial_sigma)
+        else:
+            occ_for_mask = occ
+        mask = occ_for_mask >= min_occupancy
         return occ, mask
 
     occ_first, valid_first = compute_half_occupancy(traj_first)
@@ -867,6 +876,7 @@ def compute_unit_analysis(
                 random_seed=random_seed,
                 min_shift_seconds=scfg.min_shift_seconds,
                 si_weight_mode=scfg.si_weight_mode,
+                occupancy_mask=scfg.occupancy_mask,
             )
         stability_splits.append(
             {

--- a/camap/config.py
+++ b/camap/config.py
@@ -59,6 +59,15 @@ class BaseSpatialMapConfig(BaseModel):
         ge=0.0,
         description="Minimum occupancy time (seconds) per bin.",
     )
+    occupancy_mask: Literal["raw", "smoothed"] = Field(
+        "smoothed",
+        description=(
+            "Which occupancy the min_occupancy threshold gates on: 'smoothed' "
+            "Gaussian-smoothed occupancy (default; legacy behavior, lets "
+            "never-visited bins pass via neighbor smoothing) or 'raw' per-bin "
+            "dwell time (excludes never-visited bins; typical in the literature)."
+        ),
+    )
     spatial_sigma: float = Field(
         ...,
         ge=0.0,

--- a/camap/config/example_arena_config.yaml
+++ b/camap/config/example_arena_config.yaml
@@ -16,6 +16,7 @@ behavior:
   spatial_map_2d:
     bins: 50
     min_occupancy: 0.05 # Minimum occupancy (in seconds) to include a bin in spatial map
+    occupancy_mask: smoothed  # 'smoothed' gates min_occupancy on Gaussian-smoothed occupancy (default); 'raw' = per-bin dwell
     spatial_sigma: 3  # Gaussian smoothing (in bins) for occupancy and rate maps
     n_shuffles: 1000
     random_seed: 1

--- a/camap/config/example_maze_config.yaml
+++ b/camap/config/example_maze_config.yaml
@@ -14,6 +14,7 @@ behavior:
   spatial_map_1d:
     bin_width_mm: 10
     min_occupancy: 0.05
+    occupancy_mask: smoothed  # 'smoothed' gates min_occupancy on Gaussian-smoothed occupancy (default); 'raw' = per-bin dwell
     spatial_sigma: 2
     n_shuffles: 1000
     random_seed: 42

--- a/camap/dataset/arena.py
+++ b/camap/dataset/arena.py
@@ -347,6 +347,7 @@ class ArenaDataset(BaseCaMAPDataset):
             behavior_fps=self.data_cfg.behavior.fps,
             spatial_sigma=scfg.spatial_sigma,
             min_occupancy=scfg.min_occupancy,
+            occupancy_mask=scfg.occupancy_mask,
         )
         logger.info(
             "Occupancy map: %s, %d/%d valid bins",

--- a/camap/dataset/maze.py
+++ b/camap/dataset/maze.py
@@ -431,6 +431,7 @@ class MazeDataset(BaseCaMAPDataset):
             min_occupancy=scfg.min_occupancy,
             segment_bins=self.segment_bins,
             edges=edges_arr,
+            occupancy_mask=scfg.occupancy_mask,
         )
 
         self.x_edges = self.edges_1d

--- a/tests/assets/regression_1d/analysis_config.yaml
+++ b/tests/assets/regression_1d/analysis_config.yaml
@@ -16,6 +16,7 @@ behavior:
   spatial_map_1d:
     bin_width_mm: 10.0
     min_occupancy: 0.1
+    occupancy_mask: smoothed  # pin legacy mask so the saved reference stays valid
     spatial_sigma: 3.0
     n_shuffles: 100
     random_seed: 42

--- a/tests/assets/regression_2d/analysis_config.yaml
+++ b/tests/assets/regression_2d/analysis_config.yaml
@@ -17,6 +17,7 @@ behavior:
   spatial_map_2d:
     bins: 50
     min_occupancy: 0.025
+    occupancy_mask: smoothed  # pin legacy mask so the saved reference stays valid
     spatial_sigma: 3
     n_shuffles: 100
     random_seed: 42

--- a/tests/test_analysis_spatial_2d.py
+++ b/tests/test_analysis_spatial_2d.py
@@ -80,8 +80,14 @@ def test_compute_occupancy_map(assets_dir: Path) -> None:
     })
     trajectory = trajectory.dropna()
 
+    # Reference was generated with the legacy smoothed-occupancy mask.
     occupancy, valid_mask, x_edges, y_edges = compute_occupancy_map(
-        trajectory, bins=20, behavior_fps=20.0, spatial_sigma=1.0, min_occupancy=0.1
+        trajectory,
+        bins=20,
+        behavior_fps=20.0,
+        spatial_sigma=1.0,
+        min_occupancy=0.1,
+        occupancy_mask="smoothed",
     )
 
     np.testing.assert_allclose(occupancy, ref["occupancy"], rtol=1e-10)


### PR DESCRIPTION
It adds an optional handle to use raw maps for thresholding occupancy-wise valid bins. The default is still smoothed map so this is 100% backward compatible